### PR TITLE
Update mitm6.py

### DIFF
--- a/mitm6/mitm6.py
+++ b/mitm6/mitm6.py
@@ -280,7 +280,7 @@ def parsepacket(p):
             print('Renew reply sent to %s' % p[DHCP6OptIA_NA].ianaopts[0].addr)
     if ARP in p:
         arpp = p[ARP]
-        if arpp.op is 2:
+        if arpp.op == 2:
             #Arp is-at package, update internal arp table
             arptable[arpp.hwsrc] = arpp.psrc
     if DNS in p:


### PR DESCRIPTION
Removes error usr/local/lib/python3.9/dist-packages/mitm6-0.2.2-py3.9.egg/mitm6/mitm6.py:283: SyntaxWarning: "is" with a literal. Did you mean "=="?