### PR TITLE
Fixing Router Advertisement function

### DIFF
--- a/mitm6/mitm6.py
+++ b/mitm6/mitm6.py
@@ -299,7 +299,8 @@ def setupFakeDns():
 
 def send_ra():
     # Send a Router Advertisement with the "managed" and "other" flag set, which should cause clients to use DHCPv6 and ask us for addresses
-    p = Ether(dst='33:33:00:00:00:01')/IPv6(dst='ff02::1')/ICMPv6ND_RA(M=1, O=1)
+    # routerlifetime is set to 0 in order to not adverise ourself as a gateway (RFC4861, section 4.2)
+    p = Ether(src=config.macaddr, dst='33:33:00:00:00:01')/IPv6(src=config.v6addr, dst='ff02::1')/ICMPv6ND_RA(M=1, O=1, routerlifetime=0)
     sendp(p, iface=config.default_if, verbose=False)
 
 # Whether packet capturing should stop

--- a/mitm6/mitm6.py
+++ b/mitm6/mitm6.py
@@ -300,7 +300,7 @@ def setupFakeDns():
 def send_ra():
     # Send a Router Advertisement with the "managed" and "other" flag set, which should cause clients to use DHCPv6 and ask us for addresses
     # routerlifetime is set to 0 in order to not adverise ourself as a gateway (RFC4861, section 4.2)
-    p = Ether(src=config.macaddr, dst='33:33:00:00:00:01')/IPv6(src=config.v6addr, dst='ff02::1')/ICMPv6ND_RA(M=1, O=1, routerlifetime=0)
+    p = Ether(src=config.selfmac, dst='33:33:00:00:00:01')/IPv6(src=config.selfaddr, dst='ff02::1')/ICMPv6ND_RA(M=1, O=1, routerlifetime=0)
     sendp(p, iface=config.default_if, verbose=False)
 
 # Whether packet capturing should stop


### PR DESCRIPTION
Hello!

Here is a small PR in order to fix two things :

**1: Router lifetime**
In the [blog post about mitm6](https://blog.fox-it.com/2018/01/11/mitm6-compromising-ipv4-networks-via-ipv6/), it says 

> mitm6 does not advertise itself as a gateway

However, according to [RFC4861 (section 4.2)](https://datatracker.ietf.org/doc/html/rfc4861#section-4.2)

>  Router Lifetime
16-bit unsigned integer.  [...] A Lifetime of 0 indicates that the router is not a default router and SHOULD NOT appear on the default router list.  The Router Lifetime applies only to the router's usefulness as a default router; it does not apply to information contained in other message fields or options.  Options that need time limits for their information include their own lifetime fields.

Before this PR, if you check `route PRINT` on the victime's machine you should see that the IPv6 default gateway is the attacker machine because the default `routerlifetime` value in scapy is 1800 . Thus, this PR forces the `routerlifetime` option to 0.

**2: Multiple interfaces on attacker's machine**
Force source MAC and the source IPv6 adresse of the RA packet to be adresses associated with the interface sending the packet. Before this PR, RA packet leaks the link-local adresse of my second network interface.

**As a side note**

If someone stumble upon this PR while searching about IPv6 attacks: I tried to implement a "RA only" version of mitm6 using the RDNS option of RA. However, even if Windows sets my rogue DNS server, it never uses it to resolve names. I suspect that Windows implements [RFC8106 (Section 5.3.1)](https://datatracker.ietf.org/doc/html/rfc8106#section-5.3.1):

>The DNS options from RAs and DHCP SHOULD be stored in the DNS Repository and Resolver Repository so that information from DHCP appears there first and therefore takes precedence. Thus, the DNS information from DHCP takes precedence over that from RAs for DNS queries.

Thanks for this amazing tool! :+1: 

:sunflower: 